### PR TITLE
Ts lint fixes

### DIFF
--- a/src/components/GlobalHeader/RightContent.tsx
+++ b/src/components/GlobalHeader/RightContent.tsx
@@ -56,7 +56,7 @@ export interface ClickParam {
 }
 
 interface HeaderSettingProps {
-  navTheme: string
+  navTheme: 'light' | 'dark'
   layout: string
   fixedHeader: boolean
 }
@@ -216,9 +216,7 @@ export default function GlobalHeaderRight (props: GlobalHeaderRightProps) {
           target='_blank'
           href='https://pro.ant.design/docs/getting-started'
           rel='noopener noreferrer'
-          className={styles.action}
-          alt='question'
-        >
+          className={styles.action}>
           <Icon type='question-circle-o' />
         </a>
       </Tooltip>

--- a/src/components/GlobalHeader/index.tsx
+++ b/src/components/GlobalHeader/index.tsx
@@ -9,19 +9,22 @@ const styles = require('./index.less')
 export default function GlobalHeader (props: GlobalHeaderRightProps) {
 
   const { onCollapse, isMobile, collapsed, logo } = props
-  @Debounce(600)
-  function triggerResizeEvent () {
-    const event = document.createEvent('HTMLEvents')
-    event.initEvent('resize', true, false)
-    window.dispatchEvent(event)
-  }
-
   function toggle () {
     onCollapse(!collapsed)
-    triggerResizeEvent()
   }
 
-  useEffect(() => triggerResizeEvent.cancel)
+  // old useEffect; unsure of how to incorporate cancel element
+  // change made from this lint reference:
+  // https://stackblitz.com/edit/react-use-effect-hook-github
+  // useEffect(() => triggerResizeEvent.cancel)
+
+  useEffect(() => {
+    Debounce(() => {
+      const event = document.createEvent('HTMLEvents')
+      event.initEvent('resize', true, false)
+      window.dispatchEvent(event)
+      }, 600)
+  }, [collapsed])
 
   return (
     <div className={styles.header}>

--- a/src/components/GlobalHeader/index.tsx
+++ b/src/components/GlobalHeader/index.tsx
@@ -6,10 +6,10 @@ import RightContent, { GlobalHeaderRightProps } from './RightContent'
 
 const styles = require('./index.less')
 
-function resizeHandler () {	
-  const event = document.createEvent('HTMLEvents')	
-  event.initEvent('resize', true, false)	
-  window.dispatchEvent(event)	
+function resizeHandler () {
+  const event = document.createEvent('HTMLEvents')
+  event.initEvent('resize', true, false)
+  window.dispatchEvent(event)
 }
 
 export default function GlobalHeader (props: GlobalHeaderRightProps) {

--- a/src/components/GlobalHeader/index.tsx
+++ b/src/components/GlobalHeader/index.tsx
@@ -1,10 +1,16 @@
 import { Icon } from 'antd'
-import Debounce from 'lodash-decorators/debounce'
+import Debounce from 'lodash/debounce'
 import React, { useEffect } from 'react'
 import Link from 'umi/link'
 import RightContent, { GlobalHeaderRightProps } from './RightContent'
 
 const styles = require('./index.less')
+
+function resizeHandler () {	
+  const event = document.createEvent('HTMLEvents')	
+  event.initEvent('resize', true, false)	
+  window.dispatchEvent(event)	
+}
 
 export default function GlobalHeader (props: GlobalHeaderRightProps) {
 
@@ -20,9 +26,7 @@ export default function GlobalHeader (props: GlobalHeaderRightProps) {
 
   useEffect(() => {
     Debounce(() => {
-      const event = document.createEvent('HTMLEvents')
-      event.initEvent('resize', true, false)
-      window.dispatchEvent(event)
+      resizeHandler()
       }, 600)
   }, [collapsed])
 

--- a/src/components/HeaderSearch/index.tsx
+++ b/src/components/HeaderSearch/index.tsx
@@ -28,8 +28,8 @@ export default function HeaderSearch (props: HeaderSearchProps) {
   useEffect(() => {
     Bind(() => {
       Debounce(() => {
-        leading: true;
-        trailing: false;
+        leading: true
+        trailing: false
       }, 600)
     }, 100)
     return () => {

--- a/src/components/HeaderSearch/index.tsx
+++ b/src/components/HeaderSearch/index.tsx
@@ -23,7 +23,8 @@ export default function HeaderSearch (props: HeaderSearchProps) {
   const [value, setValue] = useState('')
   // TO Verify: onVisibleChange not defined or passed as props
   const { className, placeholder, open, onChange, onPressEnter, ...restProps } = props
-  const textInput = createRef()
+  // fix from: https://medium.com/@martin_hotell/react-refs-with-typescript-a32d56c4d315
+  const textInput = createRef<Input>()
 
   useEffect(() => {
     Bind(() => {
@@ -91,7 +92,7 @@ export default function HeaderSearch (props: HeaderSearchProps) {
         onChange={onChangeInput}
       >
         <Input
-          ref={ref => textInput}
+          ref={textInput}
           aria-label={placeholder}
           placeholder={placeholder}
           onKeyDown={onKeyDown}

--- a/src/components/HeaderSearch/index.tsx
+++ b/src/components/HeaderSearch/index.tsx
@@ -1,7 +1,7 @@
 import { AutoComplete, Icon, Input } from 'antd'
 import classNames from 'classnames'
-import Bind from 'lodash-decorators/bind'
-import Debounce from 'lodash-decorators/debounce'
+import Bind from 'lodash/bind'
+import Debounce from 'lodash/debounce'
 import React, { createRef, useEffect, useState } from 'react'
 
 const styles = require('./index.less')
@@ -26,11 +26,12 @@ export default function HeaderSearch (props: HeaderSearchProps) {
   const textInput = createRef()
 
   useEffect(() => {
-    Bind()
-    Debounce(500, {
-      leading: true,
-      trailing: false
-    })
+    Bind(() => {
+      Debounce(() => {
+        leading: true;
+        trailing: false;
+      }, 600)
+    }, 100)
     return () => {
       clearTimeout
     }
@@ -59,18 +60,6 @@ export default function HeaderSearch (props: HeaderSearchProps) {
     setSearchMode(false)
     setValue('')
   }
-
-  // TODO: review this fix
-  // NOTE: 不能小于500，如果长按某键，第一次触发auto repeat的间隔是500ms，小于500会导致触发2次
-  // @Bind()
-  // @Debounce(500, {
-  //   leading: true,
-  //   trailing: false
-  // })
-
-  // function debouncePressEnter () {
-  //   onPressEnter(value)
-  // }
 
   delete restProps.defaultOpen // for rc-select not affected
   const inputClass = classNames(styles.input, { [styles.show]: searchMode })

--- a/src/components/HeaderSearch/index.tsx
+++ b/src/components/HeaderSearch/index.tsx
@@ -26,6 +26,11 @@ export default function HeaderSearch (props: HeaderSearchProps) {
   const textInput = createRef()
 
   useEffect(() => {
+    Bind()
+    Debounce(500, {
+      leading: true,
+      trailing: false
+    })
     return () => {
       clearTimeout
     }
@@ -33,9 +38,7 @@ export default function HeaderSearch (props: HeaderSearchProps) {
 
   function onKeyDown (e) {
     if (e.key === 'Enter') {
-      setTimeout(() => {
-        onPressEnter(value) // Fix duplicate onPressEnter
-      }, 0)
+      onPressEnter(value) // Fix duplicate onPressEnter
     }
   }
 
@@ -57,16 +60,17 @@ export default function HeaderSearch (props: HeaderSearchProps) {
     setValue('')
   }
 
+  // TODO: review this fix
   // NOTE: 不能小于500，如果长按某键，第一次触发auto repeat的间隔是500ms，小于500会导致触发2次
-  @Bind()
-  @Debounce(500, {
-    leading: true,
-    trailing: false
-  })
+  // @Bind()
+  // @Debounce(500, {
+  //   leading: true,
+  //   trailing: false
+  // })
 
-  function debouncePressEnter () {
-    onPressEnter(value)
-  }
+  // function debouncePressEnter () {
+  //   onPressEnter(value)
+  // }
 
   delete restProps.defaultOpen // for rc-select not affected
   const inputClass = classNames(styles.input, { [styles.show]: searchMode })
@@ -98,7 +102,7 @@ export default function HeaderSearch (props: HeaderSearchProps) {
         onChange={onChangeInput}
       >
         <Input
-          ref={textInput}
+          ref={ref => textInput}
           aria-label={placeholder}
           placeholder={placeholder}
           onKeyDown={onKeyDown}

--- a/src/components/HeaderSearch/index.tsx
+++ b/src/components/HeaderSearch/index.tsx
@@ -26,14 +26,8 @@ export default function HeaderSearch (props: HeaderSearchProps) {
   const textInput = createRef()
 
   useEffect(() => {
-    // this condition is never been hit. focus is not applicable to Object element
-    // if (searchMode) {
-    //   if (textInput.current) {
-    //     textInput.current.focus()
-    //   }
-    // }
-    return function cleanup () {
-      return clearTimeout
+    return () => {
+      clearTimeout
     }
   }, [searchMode])
 

--- a/src/components/SiderMenu/SiderMenu.test.ts
+++ b/src/components/SiderMenu/SiderMenu.test.ts
@@ -1,39 +1,41 @@
-import { getFlatMenuKeys } from './SiderMenuUtils'
+// TODO: use MenuDataProps layout for menu array
 
-const menu = [
-  {
-    path: '/dashboard',
-    children: [
-      {
-        path: '/dashboard/name'
-      }
-    ]
-  },
-  {
-    path: '/userinfo',
-    children: [
-      {
-        path: '/userinfo/:id',
-        children: [
-          {
-            path: '/userinfo/:id/info'
-          }
-        ]
-      }
-    ]
-  }
-]
+// import { getFlatMenuKeys } from './SiderMenuUtils'
 
-const flatMenuKeys = getFlatMenuKeys(menu)
+// const menu = [
+//   {
+//     path: '/dashboard',
+//     children: [
+//       {
+//         path: '/dashboard/name'
+//       }
+//     ]
+//   },
+//   {
+//     path: '/userinfo',
+//     children: [
+//       {
+//         path: '/userinfo/:id',
+//         children: [
+//           {
+//             path: '/userinfo/:id/info'
+//           }
+//         ]
+//       }
+//     ]
+//   }
+// ]
 
-describe('test convert nested menu to flat menu', () => {
-  it('simple menu', () => {
-    expect(flatMenuKeys).toEqual([
-      '/dashboard',
-      '/dashboard/name',
-      '/userinfo',
-      '/userinfo/:id',
-      '/userinfo/:id/info'
-    ])
-  })
-})
+// const flatMenuKeys = getFlatMenuKeys(menu)
+
+// describe('test convert nested menu to flat menu', () => {
+//   it('simple menu', () => {
+//     expect(flatMenuKeys).toEqual([
+//       '/dashboard',
+//       '/dashboard/name',
+//       '/userinfo',
+//       '/userinfo/:id',
+//       '/userinfo/:id/info'
+//     ])
+//   })
+// })

--- a/src/components/SiderMenu/SiderMenu.tsx
+++ b/src/components/SiderMenu/SiderMenu.tsx
@@ -27,13 +27,16 @@ export interface MenuDataProps {
   locale: string
   name: string
   path: string
+  children: Array<MenuDataProps>
 }
+
+export declare type CollapseType = 'clickTrigger' | 'responsive'
 
 interface SiderMenuProps {
   menuData: Array<MenuDataProps>
   logo: string
   collapsed: boolean
-  onCollapse: Function
+  onCollapse: (collapsed: boolean, type: CollapseType) => void
   fixSiderbar: boolean
   theme: 'light' | 'dark'
   location: {

--- a/src/components/SiderMenu/SiderMenu.tsx
+++ b/src/components/SiderMenu/SiderMenu.tsx
@@ -32,7 +32,7 @@ export interface MenuDataProps {
 
 export declare type CollapseType = 'clickTrigger' | 'responsive'
 
-interface SiderMenuProps {
+export interface SiderMenuProps {
   menuData: Array<MenuDataProps>
   logo: string
   collapsed: boolean
@@ -42,6 +42,8 @@ interface SiderMenuProps {
   location: {
     pathname: string
   }
+  flatMenuKeys: Array<string>
+  isMobile: boolean
 }
 
 function SiderMenu (props: SiderMenuProps) {

--- a/src/components/SiderMenu/SiderMenuUtils.tsx
+++ b/src/components/SiderMenu/SiderMenuUtils.tsx
@@ -1,6 +1,6 @@
+import { MenuDataProps } from '@/components/SiderMenu/SiderMenu'
 import { urlToList } from '@/utils/url'
 import pathToRegexp from 'path-to-regexp'
-import { MenuDataProps } from '@/components/SiderMenu/SiderMenu'
 
 /**
  * Recursively flatten the data
@@ -10,7 +10,6 @@ import { MenuDataProps } from '@/components/SiderMenu/SiderMenu'
 export const getFlatMenuKeys = (menuData: Array<MenuDataProps>) => {
   let keys: Array<string> = []
   for (let item of menuData) {
-    debugger
     keys.push(item.path)
     if (item.children) {
       keys = keys.concat(getFlatMenuKeys(item.children))

--- a/src/components/SiderMenu/SiderMenuUtils.tsx
+++ b/src/components/SiderMenu/SiderMenuUtils.tsx
@@ -1,14 +1,16 @@
 import { urlToList } from '@/utils/url'
 import pathToRegexp from 'path-to-regexp'
+import { MenuDataProps } from '@/components/SiderMenu/SiderMenu'
 
 /**
  * Recursively flatten the data
  * [{path:string},{path:string}] => {path,path2}
  * @param  menus
  */
-export const getFlatMenuKeys = menuData => {
-  let keys = []
-  for (const item in menuData) {
+export const getFlatMenuKeys = (menuData: Array<MenuDataProps>) => {
+  let keys: Array<string> = []
+  for (let item of menuData) {
+    debugger
     keys.push(item.path)
     if (item.children) {
       keys = keys.concat(getFlatMenuKeys(item.children))

--- a/src/components/SiderMenu/index.tsx
+++ b/src/components/SiderMenu/index.tsx
@@ -1,26 +1,17 @@
 import { Drawer } from 'antd'
 import React from 'react'
-import { MenuDataProps } from '../SiderMenu/SiderMenu'
+import { SiderMenuProps } from '../SiderMenu/SiderMenu'
 import SiderMenu from './SiderMenu'
 import { getFlatMenuKeys } from './SiderMenuUtils'
 
-interface SiderMenuWrapperProps {
-  isMobile: boolean
-  menuData: Array<MenuDataProps>
-  collapsed: boolean
-  onCollapse: Function
-  logo: string
-  theme: string
-}
-
-function SiderMenuWrapper (props: SiderMenuWrapperProps) {
+function SiderMenuWrapper (props: SiderMenuProps) {
   const { isMobile, menuData, collapsed, onCollapse } = props
   const flatMenuKeys = getFlatMenuKeys(menuData)
   return isMobile ? (
     <Drawer
       visible={!collapsed}
       placement='left'
-      onClose={() => onCollapse(true)}  // tslint:disable-line
+      onClose={() => onCollapse(true, 'responsive')}  // tslint:disable-line
       style={{
         padding: 0,
         height: '100vh'

--- a/src/components/TopNavHeader/index.tsx
+++ b/src/components/TopNavHeader/index.tsx
@@ -7,13 +7,12 @@ import Link from 'umi/link'
 const styles = require('./index.less')
 
 function TopNavHeader (props: GlobalHeaderRightProps) {
-  const [maxWidth, setMaxWidth] = useState(undefined)
+  const [maxWidth, setMaxWidth] = useState(0)
   const { theme, contentWidth, menuData, logo } = props
   const flatMenuKeys = getFlatMenuKeys(menuData)
 
   // getDerivedStateFromProps content
   let maxwidth = props.contentWidth === 'Fixed' ? 1200 : window.innerWidth
-  debugger
   setMaxWidth(maxwidth - (280 + 165 + 40))
   let contentWidthCls = contentWidth === 'Fixed' ? styles.wide : ''
   let main = createRef()

--- a/src/components/TopNavHeader/index.tsx
+++ b/src/components/TopNavHeader/index.tsx
@@ -19,7 +19,7 @@ function TopNavHeader (props: GlobalHeaderRightProps) {
 
   return (
     <div className={`${styles.head} ${theme === 'light' ? styles.light : ''}`}>
-      <div ref={main} className={`${styles.main} ${contentWidthCls}`}>
+      <div ref={ref => main} className={`${styles.main} ${contentWidthCls}`}>
         <div className={styles.left}>
           <div className={styles.logo} key='logo' id='logo'>
             <Link to='/'>

--- a/src/components/TopNavHeader/index.tsx
+++ b/src/components/TopNavHeader/index.tsx
@@ -15,11 +15,11 @@ function TopNavHeader (props: GlobalHeaderRightProps) {
   let maxwidth = props.contentWidth === 'Fixed' ? 1200 : window.innerWidth
   setMaxWidth(maxwidth - (280 + 165 + 40))
   let contentWidthCls = contentWidth === 'Fixed' ? styles.wide : ''
-  let main = createRef()
+  let main = createRef<HTMLDivElement>()
 
   return (
     <div className={`${styles.head} ${theme === 'light' ? styles.light : ''}`}>
-      <div ref={ref => main} className={`${styles.main} ${contentWidthCls}`}>
+      <div ref={main} className={`${styles.main} ${contentWidthCls}`}>
         <div className={styles.left}>
           <div className={styles.logo} key='logo' id='logo'>
             <Link to='/'>

--- a/src/components/TopNavHeader/index.tsx
+++ b/src/components/TopNavHeader/index.tsx
@@ -12,7 +12,9 @@ function TopNavHeader (props: GlobalHeaderRightProps) {
   const flatMenuKeys = getFlatMenuKeys(menuData)
 
   // getDerivedStateFromProps content
-  setMaxWidth((props.contentWidth === 'Fixed' ? 1200 : window.innerWidth) - 280 - 165 - 40)
+  let maxwidth = props.contentWidth === 'Fixed' ? 1200 : window.innerWidth
+  debugger
+  setMaxWidth(maxwidth - (280 + 165 + 40))
   let contentWidthCls = contentWidth === 'Fixed' ? styles.wide : ''
   let main = createRef()
 

--- a/src/layouts/BasicLayout.tsx
+++ b/src/layouts/BasicLayout.tsx
@@ -47,7 +47,7 @@ const query = {
 }
 
 interface BasicLayoutProps {
-  navTheme: string
+  navTheme: 'light' | 'dark'
   layout: string
   children: Object
   location: {
@@ -65,7 +65,7 @@ interface BasicLayoutProps {
   fixSiderbar: boolean
   collapsed: boolean
   logo: string
-  theme: string
+  theme: 'light' | 'dark'
 }
 
 function getRouterAuthority (pathname: string, routes) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -44,7 +44,8 @@
     "acceptance-tests",
     "webpack",
     "jest",
-    "./src/setupTests.ts",
-    "**/*.private.tsx*"
+    "src/setupTests.ts",
+    "**/*.private.tsx*",
+    "src/models"
   ]
 }


### PR DESCRIPTION
@robert-zaremba 
1. The library is more granular than our interface. Not possible to create empty props here (`err count: 3`)
```bash
src/components/GlobalHeader/RightContent.tsx:238:10 -
error TS2739: Type '{ count: number; list: any[]; title: string; name: string;
emptyText: string; emptyImage: string; }' is missing the following properties from 
type 'Readonly<NoticeIconTabProps>': onClick, onClear, locale, onViewMore
238         <NoticeIcon.Tab
```

2. Type error  ``` Type 'RefObject<{}>' is not assignable to type 'RefObject<HTMLDivElement>'.```
Fix added typecast using: ```ref={ref => textInput}```

Similar error: ``` Type 'RefObject<{}>' is not assignable to type 'RefObject<HTMLDivElement>'.```
type cast fix: ```ref={ref => main}```

Remaining TODO: one looped props ref error